### PR TITLE
Filter organization againts project permission

### DIFF
--- a/cadasta/api/organization.py
+++ b/cadasta/api/organization.py
@@ -52,6 +52,17 @@ class Organization(object):
         network = NetworkMixin(get_url_instance() + self.api_url)
         return self._call_api(network)
 
+    def organizations_project_filtered(self):
+        """Get organizations with permission to list and add project.
+
+        :return: Tuple of status request and list of organizations
+                  (if request failed return failure messages).
+        :rtype: (bool, list/str)
+        """
+        permissions = '?permissions=project.create,project.list'
+        network = NetworkMixin(get_url_instance() + self.api_url + permissions)
+        return self._call_api(network)
+
     def summary_organization(self, slug):
         """Get detail summary organization.
 

--- a/cadasta/api/test/test_organization.py
+++ b/cadasta/api/test/test_organization.py
@@ -43,6 +43,16 @@ class OrganizationTest(unittest.TestCase):
         self.assertTrue(results[0])
         self.assertIsInstance(results[1], list)
 
+    def test_project_filtered_organizations(self):
+        """Test we get organization with project filtered."""
+        organization = Organization()
+        organization._call_api = MagicMock(
+                return_value=(True, [self.test_organization])
+        )
+        results = organization.organizations_project_filtered()
+        self.assertTrue(results[0])
+        self.assertIsInstance(results[1], list)
+
     def test_get_summary_organization(self):
         """Test we get one organization by slug."""
         slug = 'allthethings'

--- a/cadasta/gui/tools/wizard/step_project_creation01.py
+++ b/cadasta/gui/tools/wizard/step_project_creation01.py
@@ -145,7 +145,7 @@ class StepProjectCreation1(WizardStep, FORM_CLASS):
         """
         LOGGER.info('Getting organisations')
         self.get_organisation_button.setEnabled(False)
-        status, results = self.organisation.all_organizations()
+        status, results = self.organisation.organizations_project_filtered()
         self.get_organisation_button.setEnabled(True)
         if status:
             self.organisation_box.clear()


### PR DESCRIPTION
Use organization api with permission filter to only list organizations that user can add project.