### PR TITLE
Bugfixes

### DIFF
--- a/cadasta/api/login.py
+++ b/cadasta/api/login.py
@@ -37,7 +37,7 @@ class Login(BaseApi):
                             catch tools result request.
         :type on_finished: Function
         """
-        super(Login, self).__init__(domain + 'api/v1/account/login/?')
+        super(Login, self).__init__(domain + '/api/v1/account/login/?')
         self.post_data.append("username=%s&" % username)
         self.post_data.append("password=%s" % password)
 

--- a/cadasta/api/organization.py
+++ b/cadasta/api/organization.py
@@ -22,7 +22,7 @@ __copyright__ = 'Copyright 2016, Cadasta'
 class Organization(object):
     """Class to fetch available organization data."""
 
-    api_url = 'api/v1/organizations/'
+    api_url = '/api/v1/organizations/'
 
     def _call_api(self, network, paginated=False):
         """Private method to execute api.

--- a/cadasta/api/organization_project.py
+++ b/cadasta/api/organization_project.py
@@ -23,7 +23,7 @@ LOGGER = logging.getLogger('CadastaQGISPlugin')
 class OrganizationProject(BaseApi):
     """Class to fetch available organization project data."""
 
-    api_url = 'api/v1/organizations/%s/projects/'
+    api_url = '/api/v1/organizations/%s/projects/'
 
     def __init__(self, organization_slug, on_finished=None):
         """Constructor.
@@ -45,7 +45,7 @@ class OrganizationProject(BaseApi):
 class OrganizationProjectSpatial(BaseApi):
     """Class to fetch available organization project spatial data."""
 
-    api_url = 'api/v1/organizations/%s/projects/%s/spatial/'
+    api_url = '/api/v1/organizations/%s/projects/%s/spatial/'
 
     def __init__(self, organization_slug, project_slug, on_finished=None):
         """Constructor.
@@ -92,7 +92,7 @@ class OrganizationProjectSpatial(BaseApi):
 class OrganizationList(BaseApi):
     """Class to fetch available organization data."""
 
-    api_url = 'api/v1/organizations/'
+    api_url = '/api/v1/organizations/'
 
     permission_query = '?permissions='
 

--- a/cadasta/api/project.py
+++ b/cadasta/api/project.py
@@ -25,7 +25,7 @@ __copyright__ = 'Copyright 2016, Cadasta'
 class Project(BaseApi):
     """Class to fetch available project data."""
 
-    api_url = 'api/v1/projects/'
+    api_url = '/api/v1/projects/'
 
     def __init__(self, on_finished=None):
         """Constructor.

--- a/cadasta/common/setting.py
+++ b/cadasta/common/setting.py
@@ -95,7 +95,7 @@ def get_url_instance():
     url = get_setting("url")
     if not url:
         url = default_domain
-    return url
+    return url.rstrip('/')
 
 
 def delete_url_instance():

--- a/cadasta/gui/tools/wizard/step_project_creation01.py
+++ b/cadasta/gui/tools/wizard/step_project_creation01.py
@@ -29,7 +29,6 @@ from cadasta.api.organization import Organization
 from cadasta.api.organization_project import OrganizationList
 from cadasta.common.setting import get_path_data
 from cadasta.model.contact import Contact
-from qgis.gui import QgsMapLayerComboBox
 from cadasta.utilities.resources import resources_path
 
 __copyright__ = "Copyright 2016, Cadasta"

--- a/cadasta/gui/tools/wizard/step_project_creation02.py
+++ b/cadasta/gui/tools/wizard/step_project_creation02.py
@@ -11,7 +11,6 @@ This module provides: Project Creation Step 2 : Attribute Selection
 
 """
 
-from qgis.gui import QgsMessageBar
 from cadasta.gui.tools.utilities.edit_text_dialog import EditTextDialog
 from cadasta.gui.tools.utilities.questionnaire import QuestionnaireUtility
 from cadasta.gui.tools.wizard.wizard_step import WizardStep

--- a/cadasta/gui/tools/wizard/step_project_creation03.py
+++ b/cadasta/gui/tools/wizard/step_project_creation03.py
@@ -12,7 +12,6 @@ This module provides: Project Creation Step 3 : Upload to cadasta
 """
 
 import os
-import json
 import logging
 from qgis.core import (
     QgsVectorLayer,

--- a/cadasta/gui/tools/wizard/step_project_download02.py
+++ b/cadasta/gui/tools/wizard/step_project_download02.py
@@ -181,7 +181,7 @@ class StepProjectDownload02(WizardStep, FORM_CLASS):
                 project_slug=project_slug)
 
         connector = ApiConnect(get_url_instance() + api)
-        status, results = connector.get()
+        status, results = connector.get(paginated=True)
 
         if not status:
             return
@@ -352,7 +352,7 @@ class StepProjectDownload02(WizardStep, FORM_CLASS):
                     spatial_unit_id=attributes[spatial_id_index]
                 )
                 connector = ApiConnect(get_url_instance() + spatial_api)
-                status, results = connector.get()
+                status, results = connector.get(paginated=True)
 
                 if not status or len(results) == 0:
                     continue

--- a/cadasta/gui/tools/wizard/step_project_update01.py
+++ b/cadasta/gui/tools/wizard/step_project_update01.py
@@ -14,13 +14,11 @@ import logging
 from PyQt4.QtGui import (
     QMovie
 )
-from PyQt4.QtCore import QCoreApplication
 from cadasta.utilities.i18n import tr
 from cadasta.gui.tools.wizard.wizard_step import WizardStep
 from cadasta.gui.tools.wizard.wizard_step import get_wizard_step_ui_class
 from cadasta.utilities.resources import resources_path
 from cadasta.utilities.utilities import Utilities
-from cadasta.api.organization import Organization
 from cadasta.api.organization_project import OrganizationList
 
 __copyright__ = "Copyright 2016, Cadasta"

--- a/cadasta/mixin/network_mixin.py
+++ b/cadasta/mixin/network_mixin.py
@@ -220,7 +220,7 @@ class NetworkMixin(object):
                 }
             }
         """
-        old_data = json.loads(old_data_str)
+        old_data = json.loads(old_data_str or 'null')
         new_data = json.loads(new_data_str)
         if not old_data:
             return json.dumps(new_data['results'])


### PR DESCRIPTION
A collection of small fixes:

* Normalize the format of API endpoints used throughout the codebase. These endpoints are added to `cadasta.common.setting.get_url_instance()`. It was ambitious is `get_url_instance()` returned a URL that ended with a trailing slash (`/`). It appeared that some API requests were being made to `https://host//...`, where two slashes existed between the URL base and the endpoint. Instead, we'll ensure that `get_url_instance()` does not end in a trailing slash and expect that all API endpoints begin with a slash.
* Fix bug around handling paginated GeoJSON
* Update `parties` and `relationships` API requests to expect paginated responses
* Remove unused imports